### PR TITLE
Fix issue with Pokemon not displaying after sorting in market screen

### DIFF
--- a/pokelife-qol.user.js
+++ b/pokelife-qol.user.js
@@ -161,8 +161,7 @@ const sortPokemonByValue = () => {
 	const fragment = document.createDocumentFragment()
 
 	// Append sorted elements to the fragment
-	sortedPokemons.forEach((pokemon) => fragment.appendChild(pokemon))
-
+	sortedPokemons.forEach((pokemon) => fragment.appendChild(pokemon.cloneNode(true)))
 	// Clear existing elements and append the fragment
 	removeElements(pokemonElements)
 	wrapper.appendChild(fragment)

--- a/pokelife-qol.user.js
+++ b/pokelife-qol.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Pokelife QoL
 // @namespace    https://github.com/Damian764/PokelifeQoL
-// @version      1.1.0
+// @version      1.1.1
 // @updateURL    https://github.com/Damian764/PokelifeQoL/raw/refs/heads/main/pokelife-qol.user.js
 // @downloadURL  https://github.com/Damian764/PokelifeQoL/raw/refs/heads/main/pokelife-qol.user.js
 // @supportURL   https://github.com/Damian764/PokelifeQoL/issues


### PR DESCRIPTION
Fixed DOM update by appending cloned Pokemon elements to the fragment instead of the original ones, preventing deletion by the removeElement function.